### PR TITLE
Update ingress to v1 API

### DIFF
--- a/charts/seq/Chart.yaml
+++ b/charts/seq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: seq
-version: __VERSION__
-appVersion: __VERSION__
+version: latest
+appVersion: latest
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:
 - seq

--- a/charts/seq/templates/_helpers.tpl
+++ b/charts/seq/templates/_helpers.tpl
@@ -43,17 +43,6 @@ Return the appropriate apiVersion for deployment.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "ingress.apiVersion" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
-{{- print "extensions/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create the name of the service account to use - only used when podsecuritypolicy is also enabled
 */}}
 {{- define "seq.serviceAccountName" -}}

--- a/charts/seq/templates/ingress.yaml
+++ b/charts/seq/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{- if or .Values.ui.ingress.enabled .Values.ingestion.ingress.enabled }}
-{{- $serviceName := include "seq.fullname" . -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $name := include "seq.fullname" . -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $serviceName }}
+  name: {{ $name }}
   labels:
     app: {{ template "seq.name" . }}
     chart: {{ template "seq.chart" . }}
@@ -36,9 +36,12 @@ spec:
       http:
         paths:
           - path: {{ $uiPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $uiPort }}
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $uiPort }}
   {{- end }}
   {{- end }}
   {{ if .Values.ingestion.ingress.enabled }}
@@ -49,9 +52,12 @@ spec:
       http:
         paths:
           - path: {{ $ingestionPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $ingestionPort }}
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $ingestionPort }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This updates our ingress configuration to use the stable `v1` version of the API instead of the beta. There are a couple of differences, but the way we're using the underlying API should map to how we expose configuration to upstream users.