### PR TITLE
Add support for imagePullSecrets

### DIFF
--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -137,18 +137,22 @@ spec:
               add:
                 - NET_BIND_SERVICE
 {{- end }}
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
-    {{- end }}
+{{- end }}
       serviceAccountName: "{{ template "seq.serviceAccountName" . }}"
       volumes:
       - name: seq-data

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -98,6 +98,8 @@ tolerations: []
 
 affinity: {}
 
+imagePullSecrets: []
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 persistence:


### PR DESCRIPTION
Closes #5

This adds support for [`imagePullSecrets`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).

cc @prochnowc