### PR TITLE
Add a complete sample using the Seq container

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ for [Seq](https://datalust.co/seq), a search and analysis server for structured 
 
 **For details of how to get started with Seq in Kubernetes, check out [the documentation](https://docs.datalust.co/docs/using-helm).**
 
+Also see the `samples` directory here for a practical walkthrough.
+
 ## Acknowledgements
 
 This chart was originally published [in the Helm v1 repository](https://github.com/helm/charts/tree/master/stable/seq), with contributions from @adamchester, @cpanato, @emmekappa, @gertjvr, @ggmaresca, @jonstelly, @KodrAus and @msschl :star_struck:.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,21 @@
+# Getting started with Seq in Kubernetes
+
+[Kubernetes](https://kubernetes.io/docs/home/) is a system for container orchestration with first-class support in most clouds. It comes with a lot of new terminology so it can take some time to get familiar with.
+
+This sample will set up Seq in a Kubernetes cluster on your local machine. It uses scripts written in [PowerShell](https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell) and has been tested on Windows and OSX using [Docker Desktop](https://www.docker.com/products/docker-desktop). It has the following main pieces:
+
+- The [Kubernetes dashboard](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/), in `./dashboard`, for visualizing and exploring the health of your cluster.
+- An [nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/), in `./nginx-controller`, to allow traffic from outside the cluster to reach our Seq instance.
+- A [Fluent Bit daemon](https://docs.fluentbit.io/manual/installation/kubernetes), in `./fluent-bit`, for collecting logs from applications running in our cluster and forwarding them to Seq.
+- A [Seq instance](https://docs.datalust.co/docs), in `./seq`, for storing, analyzing, and visualizing log data.
+- A sample application, in `./app`, deployed to our cluster that will produce log events.
+
+If you're starting from fresh with an empty Kubernetes cluster, you can run a script that will set everything up for you:
+
+```shell
+./apply.ps1
+```
+
+If you'd like to set up individual bits directly, you can run the `apply.ps1` scripts you find in their directories.
+
+Take a look through the subdirectories in here to see some more details about what each piece does and how to interact with it.

--- a/samples/app/README.md
+++ b/samples/app/README.md
@@ -1,0 +1,3 @@
+# `counter`
+
+When this application logs to one of its output streams, those logs will get picked up by the `fluennt-bit` collector and forwarded to our `sqelf` container, which then forwards on to Seq.

--- a/samples/app/app.yaml
+++ b/samples/app/app.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: counter
+spec:
+  containers:
+  - name: count
+    image: ubuntu:20.04
+    args: [/bin/sh, -c, 'i=0; while true; do echo "{\"@l\":\"info\",\"@mt\":\"{i}: {date}\",\"i\":$i,\"date\":\"$(date)\"}"; i=$((i+1)); sleep 1; done']

--- a/samples/app/apply.ps1
+++ b/samples/app/apply.ps1
@@ -1,0 +1,6 @@
+Push-Location $PSScriptRoot
+
+kubectl delete pod counter
+kubectl apply -f app.yaml
+
+Pop-Location

--- a/samples/apply.ps1
+++ b/samples/apply.ps1
@@ -1,0 +1,24 @@
+Push-Location $PSScriptRoot
+
+helm repo add datalust https://helm.datalust.co
+
+# Create the dashboard for exploring our cluster
+./dashboard/apply.ps1
+
+# Create the ingress controller for exposing our Seq instance
+./nginx-controller/apply.ps1
+
+# Create the Seq pod for storing and searching logs
+./seq/apply.ps1
+
+# Create the fluent-bit daemon for collecting container logs
+./fluent-bit/apply.ps1
+
+# Create a test application that produces some logs
+./app/apply.ps1
+
+Write-Warning "Add `127.0.0.1 seq-dev.local` to your `hosts` file"
+
+Start-Process "http://seq-dev.local"
+
+Pop-Location

--- a/samples/dashboard/README.md
+++ b/samples/dashboard/README.md
@@ -1,0 +1,19 @@
+# Deploying the dashboard
+
+Here we've got some scripts to set up a dashboard app that can be used to see what the cluster is up to when we create deployments in it.
+
+Run the `apply.ps1` script to deploy the dashboard and a user that can access it.
+
+## `kubernetes-dashboard`
+
+From: https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/
+
+## `dashboard-user`
+
+From: https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md
+
+You need a user to access the dashboard with. The example creates a cluster admin user and tells you it's a really bad idea but gives you no direction on what a good user might look like. So... cluster admin it is!
+
+# Accessing the dashboard
+
+Run the `serve.ps1` script to serve the dashboard, proxy access to it and print a token we can use to log in to it.

--- a/samples/dashboard/apply.ps1
+++ b/samples/dashboard/apply.ps1
@@ -1,0 +1,5 @@
+Push-Location $PSScriptRoot
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.3.1/aio/deploy/recommended.yaml
+
+Pop-Location

--- a/samples/dashboard/get-token.ps1
+++ b/samples/dashboard/get-token.ps1
@@ -1,0 +1,5 @@
+Push-Location $PSScriptRoot
+
+kubectl -n kubernetes-dashboard describe secret $(kubectl -n kubernetes-dashboard get secret | Select-String admin-user | ForEach-Object { $_ -Split '\s+' } | Select-Object -First 1)
+
+Pop-Location

--- a/samples/dashboard/rolebinding.yaml
+++ b/samples/dashboard/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dashboard-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: dashboard-user
+  namespace: kubernetes-dashboard

--- a/samples/dashboard/serve.ps1
+++ b/samples/dashboard/serve.ps1
@@ -1,0 +1,7 @@
+Push-Location $PSScriptRoot
+
+Start-Job -ScriptBlock { kubectl proxy }
+./get-token.ps1
+Start-Process http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
+
+Pop-Location

--- a/samples/dashboard/serviceaccount.yaml
+++ b/samples/dashboard/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dashboard-user
+  namespace: kubernetes-dashboard

--- a/samples/fluent-bit/README.md
+++ b/samples/fluent-bit/README.md
@@ -1,0 +1,11 @@
+# Collecting app and system logs
+
+[Fluent Bit](https://fluentbit.io/) is a successor to [`fluentd`](https://www.fluentd.org/). It's a generic data collector, like [Logstash](https://www.elastic.co/logstash/), that is natively in Kubernetes.
+
+Run the `apply.ps1` script to deploy the collector so that logs will start getting forwarded.
+
+## `fluent-bit`
+
+We create a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/), which ensures an instance of the `fluent-bit` collector runs on every [Node](https://kubernetes.io/docs/concepts/architecture/nodes/) in our cluster. This collector will listen for new logs from application containers and forward them via UDP to Seq in the [Graylog format](https://www.graylog.org/features/gelf).
+
+The configuration for ingesting logs from Kubernetes sources comes from a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/).

--- a/samples/fluent-bit/apply.ps1
+++ b/samples/fluent-bit/apply.ps1
@@ -1,0 +1,11 @@
+Push-Location $PSScriptRoot
+
+kubectl create namespace logging
+kubectl apply -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
+
+kubectl apply -f config.yaml
+kubectl apply -f daemon.yaml
+
+Pop-Location

--- a/samples/fluent-bit/config.yaml
+++ b/samples/fluent-bit/config.yaml
@@ -1,0 +1,87 @@
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: logging
+apiVersion: v1
+data:
+    # Configuration files: server, input, filters and output
+    # ======================================================
+    fluent-bit.conf: |
+      [SERVICE]
+          Flush         1
+          Log_Level     info
+          Daemon        off
+          Parsers_File  parsers.conf
+      @INCLUDE input-kubernetes.conf
+      @INCLUDE filter-kubernetes.conf
+      @INCLUDE output-gelf.conf
+    input-kubernetes.conf: |
+      [INPUT]
+          Name              tail
+          Tag               kube.*
+          Path              /var/log/containers/*.log
+          Parser            docker
+          DB                /var/log/flb_kube.db
+          Mem_Buf_Limit     5MB
+          Skip_Long_Lines   On
+          Refresh_Interval  10
+    filter-kubernetes.conf: |
+      [FILTER]
+          Name                kubernetes
+          Match               kube.*
+          Kube_URL            https://kubernetes.default.svc:443
+          Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+          Kube_Tag_Prefix     kube.var.log.containers.
+          Merge_Log           On
+          Merge_Log_Key       log_processed
+          K8S-Logging.Parser  On
+          K8S-Logging.Exclude Off
+    output-gelf.conf: |
+      [OUTPUT]
+          Name                    gelf
+          Match                   kube.*
+          Host                    ${FLUENT_GELF_HOST}
+          Port                    ${FLUENT_GELF_PORT}
+          Mode                    ${FLUENT_GELF_PROTOCOL}
+          Gelf_Short_Message_Key  log
+    parsers.conf: |
+      [PARSER]
+          Name   apache
+          Format regex
+          Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+          Time_Key time
+          Time_Format %d/%b/%Y:%H:%M:%S %z
+      [PARSER]
+          Name   apache2
+          Format regex
+          Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+          Time_Key time
+          Time_Format %d/%b/%Y:%H:%M:%S %z
+      [PARSER]
+          Name   apache_error
+          Format regex
+          Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+      [PARSER]
+          Name   nginx
+          Format regex
+          Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+          Time_Key time
+          Time_Format %d/%b/%Y:%H:%M:%S %z
+      [PARSER]
+          Name   json
+          Format json
+          Time_Key time
+          Time_Format %d/%b/%Y:%H:%M:%S %z
+      [PARSER]
+          Name        docker
+          Format      json
+          Time_Key    time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L
+          Time_Keep   On
+      [PARSER]
+          Name        syslog
+          Format      regex
+          Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+          Time_Key    time
+          Time_Format %b %d %H:%M:%S

--- a/samples/fluent-bit/daemon.yaml
+++ b/samples/fluent-bit/daemon.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:1.3.11
+        imagePullPolicy: Always
+        env:
+        - name: FLUENT_GELF_HOST
+          value: "seq-dev.default.svc.cluster.local"
+        - name: FLUENT_GELF_PORT
+          value: "12201"
+        - name: FLUENT_GELF_PROTOCOL
+          value: "tcp"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"

--- a/samples/nginx-controller/README.md
+++ b/samples/nginx-controller/README.md
@@ -1,0 +1,13 @@
+# Deploying an ingress controller
+
+Here we deploy a default [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) based on [nginx](https://nginx.org/en/).
+
+Run the `apply.ps1` script to deploy our ingress controller.
+
+## `ingress-nginx`
+
+From: https://kubernetes.github.io/ingress-nginx/deploy/
+
+What's an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)? It allows you to open access to your applications to users outside of your cluster. Without an ingress, the applications in your cluster can still see eachother, but nobody outside of it can see them.
+
+Ingress isn't a piece of infrastructure that enables proxying to services in your cluster. It's more like a request for proxying support that some other service can handle. That other service is the [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). In this sample, that controller is [nginx](https://nginx.org/en/), a popular reverse proxy and HTTP server.

--- a/samples/nginx-controller/apply.ps1
+++ b/samples/nginx-controller/apply.ps1
@@ -1,0 +1,9 @@
+Push-Location $PSScriptRoot
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.47.0/deploy/static/provider/cloud/deploy.yaml
+kubectl wait --namespace ingress-nginx `
+  --for=condition=ready pod `
+  --selector=app.kubernetes.io/component=controller `
+  --timeout=120s
+
+Pop-Location

--- a/samples/seq/README.md
+++ b/samples/seq/README.md
@@ -1,0 +1,68 @@
+# Deploying Seq
+
+Here we have scripts for configuring and deploying a Seq instance into our cluster.
+
+Run the `apply.ps1` script to remove an existing Seq instance and recreate it. Run the `upgrade.ps1` script to upgrade an existing Seq instance in place.
+
+## `seq`
+
+There's a package manager for Kubernetes called [Helm](https://helm.sh/docs/). Seq has a [Helm Chart](https://helm.sh/docs/topics/charts/) which can be used to simplify deployment of a Seq server in a cluster. Helm will replace default parameters with the ones we specify in our `config.yaml` when creating the deployment.
+
+### Deployment strategy
+
+The chart uses a [Recreate Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) to make sure there's only ever a single container going and accessing storage at a time.
+
+### Ingress
+
+Corresponds to the `ui` and `ingestion` sections of the YAML configuration.
+
+It supports [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) to the full UI/API and/or just the limited ingestion port. The [nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) will typically route traffic to a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) (like our Seq instance) using the host header. That means if you want to see your Seq instance on a local cluster then you'll need to edit your `hosts` file (that's at `$SYSTEM32/drivers/etc/hosts` on Windows or `/etc/hosts` on OSX) to point `127.0.0.1` to whatever hostname you configure Seq's _ingress_ to use. As an example, I have this in my `hosts` file:
+
+```
+127.0.0.1 seq-dev.local
+127.0.0.1 seq-dev-ingest.local
+
+127.0.0.1 kubernetes.docker.internal
+```
+
+The way Seq's Helm Chart is designed right now it's really only feasible to split ingestion and UI by hostname, rather than by path or port. So if you want to expose both publicly you'd use:
+
+```shell
+# UI
+ui.seq.mydomain.com:443
+
+# Ingestion
+ingest.seq.mydomain.com:443
+```
+
+rather than:
+
+```shell
+# UI
+seq.mydomain.com:443
+
+# Ingestion
+seq.mydomain.com:5341
+```
+
+### Storage
+
+Corresponds to the `persistence` section of the YAML configuration.
+
+Seq stores its data on disk, so the chart uses a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to keep log data. That way, if the container is moved between actual nodes it will keep its configuration and data.
+
+The chart may be deployed with a new or an existing claim.
+
+### CPU and Memory
+
+Corresponds to the `resources` section of the YAML configuration.
+
+### GELF
+
+The chart doesn't just deploy a `datalust/seq` container. When we enable `gelf` it'll also deploy a `datalust/sqelf` container alongside it, that can forward Graylog events into the Seq container. This is nice because Graylog has ready support in Kubernetes using `fluent-bit`, so applications that aren't using a logging framework with Seq support can simply log to `stdout` and still have their log events collected.
+
+# Accessing Seq
+
+You can access Seq using the hostname configured in `config.yaml`, or by running `serve.ps1` to access it directly, like the dashboard.
+
+Internally, Seq will be available as `seq-dev.default.svc.cluster.local`, because we called our service `seq-dev`, and deployed it to the `default` namespace.

--- a/samples/seq/apply.ps1
+++ b/samples/seq/apply.ps1
@@ -1,0 +1,12 @@
+Push-Location $PSScriptRoot
+
+$chart = $env:SEQ_HELM_CHART_OR_PATH
+if ($null -eq $chart) {
+    $chart = "datalust/seq"
+}
+
+helm uninstall seq-dev
+helm repo update
+helm install -f config.yaml seq-dev $chart
+
+Pop-Location

--- a/samples/seq/config.yaml
+++ b/samples/seq/config.yaml
@@ -1,0 +1,25 @@
+resources:
+  limits:
+    memory: "1Gi"
+
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+
+ui:
+  ingress:
+    enabled: true
+    path: /
+    hosts:
+      - seq-dev.local
+ingestion:
+  ingress:
+    enabled: true
+    path: /
+    hosts:
+      - seq-dev-ingest.local
+gelf:
+  enabled: true

--- a/samples/seq/serve.ps1
+++ b/samples/seq/serve.ps1
@@ -1,0 +1,6 @@
+Push-Location $PSScriptRoot
+
+Start-Job -ScriptBlock { kubectl proxy }
+Start-Process http://localhost:8001/api/v1/namespaces/default/services/seq-dev:80/proxy/
+
+Pop-Location

--- a/samples/seq/upgrade.ps1
+++ b/samples/seq/upgrade.ps1
@@ -1,0 +1,5 @@
+Push-Location $PSScriptRoot
+
+helm upgrade -f config.yaml seq-dev stable/seq
+
+Pop-Location


### PR DESCRIPTION
This PR introduces a complete sample using the Seq helm chart that includes the GELF container for collecting container logs from services that aren't configured to write to Seq directly.