### PR TITLE
Use localhost for communication between Seq Gelf Input and Seq containers

### DIFF
--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           imagePullPolicy: {{ .Values.gelf.image.pullPolicy }}
           env:
             - name: "SEQ_ADDRESS"
-              value: "http://{{ template "seq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.ingestion.service.port }}"
+              value: "http://localhost:{{ .Values.ingestion.service.port }}"
             - name: "SEQ_API_KEY"
               value: "{{ .Values.gelf.apiKey }}"
             - name: "GELF_ADDRESS"


### PR DESCRIPTION
Since both the Seq Gelf Input and Seq containers are run within the same pod, we can rely on using `localhost` according to [this document](https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking). This makes it possible to roll-out Seq using Helm in a cluster that has a non-default DNS domain (ie. something other than `.cluster.local`).

Fixes #16 