### PR TITLE
Just use localhost part 2

### DIFF
--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
           imagePullPolicy: {{ .Values.syslog.image.pullPolicy }}
           env:
             - name: "SEQ_ADDRESS"
-              value: "http://{{ template "seq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.ingestion.service.port }}"
+              value: "http://localhost:{{ .Values.ingestion.service.port }}"
             - name: "SEQ_API_KEY"
               value: "{{ .Values.syslog.apiKey }}"
             - name: "SYSLOG_ADDRESS"


### PR DESCRIPTION
Follow-up to #17

This makes the same change for `syslog` where it turns out we can rely on `localhost` for communication between containers in the same pod.