### PR TITLE
Demonstrate how to set the version of the Seq container on install

### DIFF
--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -4,6 +4,9 @@
 
 image:
   repository: datalust/seq
+  # Specify a tag to pull a specific version of the Seq container
+  # By default the version of the chart will be used as the tag
+  # tag: latest
   pullPolicy: IfNotPresent
 
 # By passing the value Y in the ACCEPT_EULA environment variable,

--- a/samples/seq/config.yaml
+++ b/samples/seq/config.yaml
@@ -1,3 +1,6 @@
+image:
+  repository: datalust/seq:latest
+
 resources:
   limits:
     memory: "1Gi"

--- a/samples/seq/config.yaml
+++ b/samples/seq/config.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: datalust/seq:latest
+  tag: latest
 
 resources:
   limits:


### PR DESCRIPTION
This PR just calls out how to set the version of the Seq container to use when installing the Helm chart. Setting the `image.tag` property will pull a specific version of the container, which doesn't have to match the version of the chart.