### PR TITLE
Make versions in chart explicit

### DIFF
--- a/charts/seq/Chart.yaml
+++ b/charts/seq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: seq
-version: 0.0.0
-appVersion: latest
+version: 2023.2.0
+appVersion: 2023.2
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:
 - seq


### PR DESCRIPTION
This PR makes the versioning of the chart explicit, so we'll update it to line up with GitHub releases. The version of the chart isn't necessarily exactly the same as `datalust/seq`, but kept in-sync enough that users should be able to apply the `{year}.{minor}` versioning scheme to any Seq-related projects they interact with.

The process for making a release would then be:

1. Merge some changes to the chart definition
2. Create a release PR that updates the build number appropriately
3. After merging the release PR, create a GitHub release with the same version

New major/minor Seq versions will run similarly, except they'll likely only need to update the versions in the `Chart.yaml` file.