### PR TITLE
Remove obsolete `SEQ_CACHE_SYSTEMRAMTARGET` setting; remap baseUri param to `SEQ_API_CANONICALURI`

### DIFF
--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -28,15 +28,13 @@ spec:
             - name: "ACCEPT_EULA"
               value: "{{ .Values.acceptEULA }}"
 {{- if .Values.baseURI }}
-            - name: "BASE_URI"
+            - name: "SEQ_API_CANONICALURI"
               value: "{{ .Values.baseURI }}"
 {{- end }}
 {{- if .Values.listenURI }}
             - name: SEQ_API_LISTENURIS
               value: "{{ .Values.listenURI }}"
 {{- end }}
-            - name: "SEQ_CACHE_SYSTEMRAMTARGET"
-              value: "{{ .Values.cache.targetSize }}"
 {{- if .Values.firstRunAdminUsername }}
             - name: "SEQ_FIRSTRUN_ADMINUSERNAME"
               value: "{{ .Values.firstRunAdminUsername }}"

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -128,13 +128,6 @@ resources: {}
   # limits:
   #  memory: 2Gi
 
-cache:
-  # The fraction of RAM that the cache should try fit within. Specifying a larger
-  # value may allow more events in RAM at the expense of potential instability.
-  # Setting it to `0` will disable the cache completely.
-  # 60% (`0.6`) is a good starting point for machines with up to ~8GB of RAM.
-  targetSize: 0.6
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
The former is no longer observed; the latter is the updated environment variable supporting the same functionality.