### PR TITLE
Add support for extraVolumes, extraVolumeMounts, and extraEnvs

### DIFF
--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               value: "{{ .Values.firstRunRequireAuthenticationForHttpIngestion }}"
 {{- end }}
 {{- if .Values.addiotnalEnv }}
-{{ toYaml .Values.additionalEnv | indent 12 }}
+{{ toYaml .Values.extraEnvs | indent 12 }}
 {{- end }}
           ports:
             - name: ingestion
@@ -93,8 +93,8 @@ spec:
             - name: seq-data
               mountPath: {{ .Values.persistence.path }}
               subPath: {{ .Values.persistence.subPath }}
-{{- if .Values.additionalVolumeMounts }}
-{{ toYaml .Values.additionalVolumeMounts | indent 12 }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -163,6 +163,6 @@ spec:
 {{- else }}
           emptyDir: {}
 {{- end }}
-{{- if .Values.additionalVolumes }}
-{{ toYaml .Values.additionalVolumes | indent 8 }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}

--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - name: "SEQ_FIRSTRUN_REQUIREAUTHENTICATIONFORHTTPINGESTION"
               value: "{{ .Values.firstRunRequireAuthenticationForHttpIngestion }}"
 {{- end }}
+{{- if .Values.addiotnalEnv }}
+{{ toYaml .Values.additionalEnv | indent 12 }}
+{{- end }}
           ports:
             - name: ingestion
               containerPort: {{ .Values.ingestion.containerPort }}
@@ -87,9 +90,12 @@ spec:
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
 {{- end }}
           volumeMounts:
-          - name: seq-data
-            mountPath: {{ .Values.persistence.path }}
-            subPath: {{ .Values.persistence.subPath }}
+            - name: seq-data
+              mountPath: {{ .Values.persistence.path }}
+              subPath: {{ .Values.persistence.subPath }}
+{{- if .Values.additionalVolumeMounts }}
+{{ toYaml .Values.additionalVolumeMounts | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.gelf.enabled }}
@@ -150,10 +156,13 @@ spec:
 {{- end }}
       serviceAccountName: "{{ template "seq.serviceAccountName" . }}"
       volumes:
-      - name: seq-data
+        - name: seq-data
 {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "seq.fullname" .) }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "seq.fullname" .) }}
 {{- else }}
-        emptyDir: {}
-{{- end -}}
+          emptyDir: {}
+{{- end }}
+{{- if .Values.additionalVolumes }}
+{{ toYaml .Values.additionalVolumes | indent 8 }}
+{{- end }}

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -194,3 +194,20 @@ startupProbe:
   enabled: true
   failureThreshold: 30
   periodSeconds: 10
+
+# Additional volumes to mount on the Seq container
+# These can be used to mount init scripts and certificates
+additionalVolumes: []
+# - name: seq-setup-volume
+#   configMap:
+#     name: seq-setup-map
+additionalVolumeMounts: []
+# - name: seq-setup-volume
+#   mountPath: /extra-stuff
+
+# Additional environment variables to set on the Seq container
+# These can be used to set Seq configuration values that aren't
+# exposed directly through the chart
+additionalEnv: []
+# - name: MY_ENV_VAR
+#   value: "Some Value"

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -197,17 +197,17 @@ startupProbe:
 
 # Additional volumes to mount on the Seq container
 # These can be used to mount init scripts and certificates
-additionalVolumes: []
+extraVolumes: []
 # - name: seq-setup-volume
 #   configMap:
 #     name: seq-setup-map
-additionalVolumeMounts: []
+extraVolumeMounts: []
 # - name: seq-setup-volume
 #   mountPath: /extra-stuff
 
 # Additional environment variables to set on the Seq container
 # These can be used to set Seq configuration values that aren't
 # exposed directly through the chart
-additionalEnv: []
+extraEnvs: []
 # - name: MY_ENV_VAR
 #   value: "Some Value"


### PR DESCRIPTION
Closes #21
Closes #36 

This PR adds support for specifying additional entries for the deployment's `env`, `volumes`, and `volumeMounts` using the `extraEnvs`, `extraVolumes`, and `extraVolumeMounts` properties in a `values.yaml`. The naming here follows the convention set by other charts.