### PR TITLE
Update to Seq 2025.2

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,10 +26,10 @@ jobs:
         uses: helm/chart-testing-action@v2.7.0
 
       - name: Lint
-        run: ct lint --charts charts/seq --helm-extra-args "--set firstRunNoAuthentication=true"
+        run: ct lint --charts charts/seq --set firstRunNoAuthentication=true
 
       - name: Create Cluster
         uses: helm/kind-action@v1.2.0
 
       - name: Install
-        run: ct install --charts charts/seq --helm-extra-args "--set firstRunNoAuthentication=true"
+        run: ct install --charts charts/seq --set firstRunNoAuthentication=true

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,10 +26,10 @@ jobs:
         uses: helm/chart-testing-action@v2.7.0
 
       - name: Lint
-        run: ct lint --charts charts/seq --set firstRunNoAuthentication=true
+        run: "ct lint --charts charts/seq --helm-lint-extra-args '--set firstRunNoAuthentication=true'"
 
       - name: Create Cluster
         uses: helm/kind-action@v1.2.0
 
       - name: Install
-        run: ct install --charts charts/seq --set firstRunNoAuthentication=true
+        run: "ct install --charts charts/seq --helm-extra-args '--set firstRunNoAuthentication=true'"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -32,4 +32,4 @@ jobs:
         uses: helm/kind-action@v1.2.0
 
       - name: Install
-        run: "ct install --charts charts/seq --helm-extra-args '--set firstRunNoAuthentication=true'"
+        run: "ct install --charts charts/seq --helm-extra-set-args '--set firstRunAdminPassword=YourP@55word'"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,10 +26,10 @@ jobs:
         uses: helm/chart-testing-action@v2.7.0
 
       - name: Lint
-        run: ct lint --charts charts/seq
+        run: ct lint --charts charts/seq --helm-extra-args "--set firstRunNoAuthentication=true"
 
       - name: Create Cluster
         uses: helm/kind-action@v1.2.0
 
       - name: Install
-        run: ct install --charts charts/seq
+        run: ct install --charts charts/seq --helm-extra-args "--set firstRunNoAuthentication=true"

--- a/charts/seq/Chart.yaml
+++ b/charts/seq/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: seq
-version: "2025.1.1"
-appVersion: "2025.1"
-description: Seq is the easiest way for development teams to capture, search and visualize structured log events!
+version: "2025.2.1"
+appVersion: "2025.2"
+description: Seq is the easiest way for development teams to capture, search and visualize structured logs and traces
 keywords:
 - seq
 - structured

--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
             - name: "SEQ_FIRSTRUN_REQUIREAUTHENTICATIONFORHTTPINGESTION"
               value: "{{ .Values.firstRunRequireAuthenticationForHttpIngestion }}"
 {{- end }}
+{{- if .Values.firstRunNoAuthentication }}
+            - name: "SEQ_FIRSTRUN_NOAUTHENTICATION"
+              value: "True"
+{{- end }}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 12 }}
 {{- end }}
@@ -176,6 +180,6 @@ spec:
 
 # At least one of the default password variables must be set; note that this ignores SEQ_PASSWORD, but
 # that variable is just a convenience alias for SEQ_FIRSTRUN_ADMINPASSWORD anyway.
-{{- if not (or .Values.firstRunAdminPassword .Values.firstRunAdminPasswordHash) }}
-{{- fail "At least one of firstRunAdminPassword or firstRunAdminPasswordHash must be specified." }}
+{{- if not (or .Values.firstRunNoAuthentication .Values.firstRunAdminPassword .Values.firstRunAdminPasswordHash) }}
+{{- fail "One of firstRunAdminPassword or firstRunAdminPasswordHash must be specified." }}
 {{- end }}

--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             - name: "SEQ_FIRSTRUN_ADMINUSERNAME"
               value: "{{ .Values.firstRunAdminUsername }}"
 {{- end }}
+{{- if .Values.firstRunAdminPassword }}
+            - name: "SEQ_FIRSTRUN_ADMINPASSWORD"
+              value: "{{ .Values.firstRunAdminPassword }}"
+{{- end }}
 {{- if .Values.firstRunAdminPasswordHash }}
             - name: "SEQ_FIRSTRUN_ADMINPASSWORDHASH"
               value: "{{ .Values.firstRunAdminPasswordHash }}"
@@ -168,4 +172,10 @@ spec:
 {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+
+# At least one of the default password variables must be set; note that this ignores SEQ_PASSWORD, but
+# that variable is just a convenience alias for SEQ_FIRSTRUN_ADMINPASSWORD anyway.
+{{- if not (or .Values.firstRunAdminPassword .Values.firstRunAdminPasswordHash) }}
+{{- fail "At least one of firstRunAdminPassword or firstRunAdminPasswordHash must be specified." }}
 {{- end }}

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -15,6 +15,16 @@ image:
 # that you intend to use.
 acceptEULA: "Y"
 
+# Seq requires a default admin password in order to initialize a fresh container. Either
+# specify this here, or see the `firstRunAdminPasswordHash` variant below for better confidentiality.
+# firstRunAdminPassword: ""
+
+# Set this to create an admin user with given password hash at first run.
+# See here for docs on how to create the password hash: https://blog.datalust.co/setting-an-initial-password-when-deploying-seq-to-docker/
+# firstRunAdminUsername: "admin"
+# firstRunAdminPasswordHash: ""
+# firstRunRequireAuthenticationForHttpIngestion: true
+
 # Set this URL if you enable ingress and/or AAD authentication.
 # Without this URL set to include HTTPS, Seq will try to set a login redirect
 # URL with HTTP instead of HTTPS and AAD's registration requires HTTPS.
@@ -25,12 +35,6 @@ acceptEULA: "Y"
 # Set the addresses that the server will listen on. The first entry listed
 # will be used as the default when generating URIs for apps and notifications.
 # listenURI: "http://localhost:80,http://localhost:5341"
-
-# Set this to create an admin user with given password hash at first run.
-# See here for docs on how to create the password hash: https://blog.datalust.co/setting-an-initial-password-when-deploying-seq-to-docker/
-# firstRunAdminUsername: "admin"
-# firstRunAdminPasswordHash: ""
-# firstRunRequireAuthenticationForHttpIngestion: true
 
 securityContext:
   runAsUser: 0

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -16,11 +16,13 @@ image:
 acceptEULA: "Y"
 
 # Seq requires a default admin password in order to initialize a fresh container. Either
-# specify this here, or see the `firstRunAdminPasswordHash` variant below for better confidentiality.
+# specify this here, or opt out using `firstRunNoAuthentication: true` (not suitable for production
+# deployment). See the `firstRunAdminPasswordHash` variant below for better confidentiality.
+firstRunNoAuthentication: false
 # firstRunAdminPassword: ""
 
-# Set this to create an admin user with given password hash at first run.
-# See here for docs on how to create the password hash: https://blog.datalust.co/setting-an-initial-password-when-deploying-seq-to-docker/
+# Further customization of the default security settings.
+# See here for docs on how to create a password hash: https://blog.datalust.co/setting-an-initial-password-when-deploying-seq-to-docker/
 # firstRunAdminUsername: "admin"
 # firstRunAdminPasswordHash: ""
 # firstRunRequireAuthenticationForHttpIngestion: true

--- a/samples/seq/config.yaml
+++ b/samples/seq/config.yaml
@@ -1,3 +1,7 @@
+# This is an insecure default; don't use this for production deployments: instead specify
+# the `firstRunAdminPassword` or `firstRunAdminPasswordHash` options.
+firstRunNoAuthentication: true
+
 image:
   tag: latest
 


### PR DESCRIPTION
A default administrator password is now required for new instances, so this is accepted via either `firstRunAdminPassword` or `firstRunAdminPasswordHash`, and a conditional block raises an error if both are missing.