### PR TITLE
feat: Allow setting SEQ_FIRSTRUN_ADMINPASSWORD and SEQ_FIRSTRUN_ADMINPASSWORDHASH from Secret

### DIFF
--- a/charts/seq/templates/deployment.yaml
+++ b/charts/seq/templates/deployment.yaml
@@ -39,13 +39,27 @@ spec:
             - name: "SEQ_FIRSTRUN_ADMINUSERNAME"
               value: "{{ .Values.firstRunAdminUsername }}"
 {{- end }}
-{{- if .Values.firstRunAdminPassword }}
+{{- if or .Values.firstRunAdminPassword .Values.firstRunAdminPasswordSecret }}
             - name: "SEQ_FIRSTRUN_ADMINPASSWORD"
+{{- if .Values.firstRunAdminPassword }}
               value: "{{ .Values.firstRunAdminPassword }}"
+{{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "A valud .Values.firstRunAdminPasswordSecret.name is required" .Values.firstRunAdminPasswordSecret.name | quote }}
+                  key: {{ required "A valud .Values.firstRunAdminPasswordSecret.key is required" .Values.firstRunAdminPasswordSecret.key | quote }}
 {{- end }}
-{{- if .Values.firstRunAdminPasswordHash }}
+{{- end }}
+{{- if or .Values.firstRunAdminPasswordHash .Values.firstRunAdminPasswordHashSecret }}
             - name: "SEQ_FIRSTRUN_ADMINPASSWORDHASH"
+{{- if .Values.firstRunAdminPasswordHash }}
               value: "{{ .Values.firstRunAdminPasswordHash }}"
+{{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "A valud .Values.firstRunAdminPasswordHashSecret.name is required" .Values.firstRunAdminPasswordHashSecret.name | quote }}
+                  key: {{ required "A valud .Values.firstRunAdminPasswordHashSecret.key is required" .Values.firstRunAdminPasswordHashSecret.key | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.firstRunRequireAuthenticationForHttpIngestion }}
             - name: "SEQ_FIRSTRUN_REQUIREAUTHENTICATIONFORHTTPINGESTION"
@@ -180,6 +194,6 @@ spec:
 
 # At least one of the default password variables must be set; note that this ignores SEQ_PASSWORD, but
 # that variable is just a convenience alias for SEQ_FIRSTRUN_ADMINPASSWORD anyway.
-{{- if not (or .Values.firstRunNoAuthentication .Values.firstRunAdminPassword .Values.firstRunAdminPasswordHash) }}
-{{- fail "One of firstRunAdminPassword or firstRunAdminPasswordHash must be specified." }}
+{{- if not (or .Values.firstRunNoAuthentication .Values.firstRunAdminPassword .Values.firstRunAdminPasswordHash .Values.firstRunAdminPasswordSecret .Values.firstRunAdminPasswordHashSecret) }}
+{{- fail "One of firstRunAdminPassword or firstRunAdminPasswordHash or firstRunAdminPasswordSecret or firstRunAdminPasswordHashSecret must be specified." }}
 {{- end }}

--- a/charts/seq/values.yaml
+++ b/charts/seq/values.yaml
@@ -20,12 +20,22 @@ acceptEULA: "Y"
 # deployment). See the `firstRunAdminPasswordHash` variant below for better confidentiality.
 firstRunNoAuthentication: false
 # firstRunAdminPassword: ""
+#
+# Alternatively, a default admin password can be provided from Kubernetes secret:
+# firstRunAdminPasswordSecret:
+#   name: "seq-admin-password-secret"
+#   key: "password"
 
 # Further customization of the default security settings.
 # See here for docs on how to create a password hash: https://blog.datalust.co/setting-an-initial-password-when-deploying-seq-to-docker/
 # firstRunAdminUsername: "admin"
 # firstRunAdminPasswordHash: ""
 # firstRunRequireAuthenticationForHttpIngestion: true
+#
+# Alternatively, a password hash can be provided from Kubernetes secret:
+# firstRunAdminPasswordHashSecret:
+#   name: "seq-admin-password-hash-secret"
+#   key: "password"
 
 # Set this URL if you enable ingress and/or AAD authentication.
 # Without this URL set to include HTTPS, Seq will try to set a login redirect


### PR DESCRIPTION
If `firstRunAdminPasswordSecret` or  `firstRunAdminPasswordHashSecret` object is defined with `name` of existing Kubernetes secret and its data `key`, hen `envFrom` is used to define the container environment variable with password or password hash value retrieved from the given secret key.


Closes #64

> [!WARNING]
> I'm Helm templates rookie, I'm not sure how to test it without releasing a new chart. There seem to be no test cases defined.

## Examples

Here are `values.yaml` samples:

```yaml
firstRunAdminPasswordSecret:
  name: my-seq-password
  key: password
```

Or, after update discussed in sub-thread that began in https://github.com/datalust/helm.datalust.co/pull/65#issuecomment-3015993092, 

```yaml
firstRunAdminPasswordHashSecret:
  name: my-seq-password-hash
  key: password
```

